### PR TITLE
모임 리스트 데이터가 undefined일 때,  메인 페이지 오류 수정

### DIFF
--- a/src/components/Main/CardList.jsx
+++ b/src/components/Main/CardList.jsx
@@ -12,9 +12,9 @@ export default function CardList() {
   if (isLoading) return <LoadingSpinner />;
   return (
     <>
-      {classes.myClasses.length === 0 ? (
-        <EmptyList />
-      ) : (
+      {(!classes || classes.myClasses.length === 0) && <EmptyList />}
+
+      {classes && (
         <ul className={styles['class-list']}>
           {classes.myClasses.map((myClass) => (
             <ClassCard key={myClass} code={myClass} />


### PR DESCRIPTION
# PR 설명
서비스에 처음 로그인 한 사용자가 DB에 등록되기 전에 `classListQuery`로 모임 리스트를 조회하여 메인 페이지에서 오류 발생

# 작업 내용
- 데이터가 undefined 인 경우 `EmptyList` 컴포넌트를 렌더링

