### PR TITLE
계좌정보를 선택 사항으로 변경 및 계좌번호를 string으로 변경

### DIFF
--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -237,14 +237,12 @@ export async function getClassDetail(code) {
 export async function updateClassHeader(uid, code, info) {
   const { title, bank, number, total, allowAnonymouse } = info;
   const amount = parseInt(total, 10);
-  const accountNumber = parseInt(number, 10);
 
-  if (title.trim().length === 0 || bank.trim().length === 0)
-    throw new Error('모임이름 또는 은행 정보를 입력해주세요.');
+  if (!title || title.trim().length === 0) throw new Error('모임 이름을 입력해주세요.');
 
   if (Number.isNaN(amount)) throw new Error('총 금액을 다시 한 번 확인해주세요.');
 
-  if (Number.isNaN(accountNumber)) throw new Error('계좌번호를 다시 한 번 확인해주세요.');
+  if (number && !checkAccountNumberRegExp(number)) throw new Error('계좌번호 숫자만 입력해주세요.');
 
   const classRef = doc(db, 'classes', code);
 
@@ -258,7 +256,7 @@ export async function updateClassHeader(uid, code, info) {
     // 총 금액 변동이 없는 경우
     if (prevTotal === amount) {
       transaction.update(classRef, {
-        account: { bank, number: accountNumber },
+        account: { bank: bank ?? '', number: number ?? '' },
         title,
         allowAnonymouse,
       });
@@ -274,7 +272,7 @@ export async function updateClassHeader(uid, code, info) {
 
     transaction.update(classRef, { history: undeletableHistories });
     transaction.update(classRef, {
-      account: { bank, number: accountNumber },
+      account: { bank: bank ?? '', number: number ?? '' },
       title,
       total: amount,
       allowAnonymouse,

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -30,6 +30,7 @@ import isMobile from '../utils/isMobile';
 import setRangeOfDeletableHistory from '../utils/setRangeOfDeletableHistory';
 import { WITHDRAW } from '../constants/bottomSheetTag';
 import sortHistory from '../utils/sortHistory';
+import checkAccountNumberRegExp from '../utils/checkAccountNumberRegExp';
 
 /**
  * firebase 문서
@@ -137,11 +138,10 @@ async function saveMemberInDB(uid, isAnonymous) {
 export async function createClass(user, info) {
   const { uid, photoURL } = user;
   const { title, bank, number, allowAnonymouse } = info;
-  const accountNumber = parseInt(number, 10);
 
-  if (!title || !bank || !number) throw new Error('모든 정보를 입력해주세요.');
+  if (!title || title.trim().length === 0) throw new Error('모임 이름을 입력해주세요.');
 
-  if (Number.isNaN(accountNumber)) throw new Error('계좌번호를 다시 한 번 확인해주세요.');
+  if (number && !checkAccountNumberRegExp(number)) throw new Error('계좌번호 숫자만 입력해주세요.');
 
   const code = generateCode();
   const batch = writeBatch(db);
@@ -149,7 +149,7 @@ export async function createClass(user, info) {
   const codeRef = doc(db, 'classes', code);
   batch.set(codeRef, {
     title,
-    account: { bank, number: accountNumber },
+    account: { bank: bank ?? '', number: number ?? '' },
     members: [{ uid, photoURL }],
     history: [],
     total: 0,

--- a/src/components/Main/ClassCard.jsx
+++ b/src/components/Main/ClassCard.jsx
@@ -12,6 +12,7 @@ export default function ClassCard({ code }) {
   } = useClassDetail(code);
 
   if (isLoading) return <LoadingCard />;
+  const { bank, number } = myClass.account;
   const [members, overLength] = showMax7Members(myClass.members);
 
   return (
@@ -20,10 +21,12 @@ export default function ClassCard({ code }) {
         <Link to='/detail' state={{ code }} className={styles.card}>
           <li className={styles['card-list']}>
             <h2 className={styles.title}>{myClass.title}</h2>
-            <dl>
-              <dt className={styles.bank}>{myClass.account.bank}</dt>
-              <dd className={styles.number}>{myClass.account.number}</dd>
-            </dl>
+            {((bank && bank.trim().length !== 0) || number) && (
+              <dl>
+                <dt className={styles.bank}>{bank && bank.trim().length !== 0 ? bank : '_'}</dt>
+                <dd className={styles.number}>{number ? number : '_'}</dd>
+              </dl>
+            )}
             <div className={styles['member-content']}>
               <ul className={styles['member-list']}>
                 {members.map((member) => (

--- a/src/components/Main/css/ClassCard.module.css
+++ b/src/components/Main/css/ClassCard.module.css
@@ -3,11 +3,7 @@
   padding: 1.5rem 0.75rem;
   margin-bottom: 1rem;
   background: rgb(166, 187, 141);
-  background: linear-gradient(
-    160deg,
-    rgba(166, 187, 141, 1) 0%,
-    rgba(234, 231, 177, 1) 100%
-  );
+  background: linear-gradient(160deg, rgba(166, 187, 141, 1) 0%, rgba(234, 231, 177, 1) 100%);
   border: 1px solid var(--color-brand);
   border-radius: 12px;
   box-shadow: rgba(0, 0, 0, 0.24) 0 3px 8px;
@@ -47,8 +43,7 @@
 }
 
 .bank {
-  min-width: 1.5rem;
-  max-width: 3.75rem;
+  max-width: 7rem;
   margin-right: 0.25rem;
 }
 

--- a/src/components/common/BottomSheet/ClassCreateForm.jsx
+++ b/src/components/common/BottomSheet/ClassCreateForm.jsx
@@ -29,16 +29,25 @@ export default function ClassCreateForm({ tag }) {
           text='모임 이름'
           value={info}
           onChange={handleChange}
+          placeholder='[필수]'
           required
         />
-        <Input type='text' name='bank' text='은행' value={info} onChange={handleChange} required />
         <Input
-          type='number'
+          type='text'
+          name='bank'
+          text='은행'
+          value={info}
+          onChange={handleChange}
+          placeholder='[선택사항]'
+        />
+        <Input
+          type='text'
+          inputMode='numeric'
           name='number'
           text='계좌번호'
           value={info}
           onChange={handleChange}
-          required
+          placeholder='[선택사항] 숫자만 입력해주세요.'
         />
         <Button text='모임 생성!' type='submit' color='yellow' isLoading={isLoading} />
       </form>

--- a/src/components/common/Input/css/Input.module.css
+++ b/src/components/common/Input/css/Input.module.css
@@ -12,6 +12,10 @@
   border-radius: 8px;
 }
 
+.input::placeholder {
+  font-size: 0.8rem;
+}
+
 .label {
   position: absolute;
   top: -0.2rem;

--- a/src/components/common/icons/css/BankIcon.module.css
+++ b/src/components/common/icons/css/BankIcon.module.css
@@ -1,4 +1,5 @@
 .icon {
+  flex-shrink: 0;
   padding: 0.1rem;
   margin-right: 0.25rem;
   font-size: 1.5rem;

--- a/src/pages/Detail/DetailHeader.jsx
+++ b/src/pages/Detail/DetailHeader.jsx
@@ -5,17 +5,24 @@ import BankIcon from '../../components/common/icons/BankIcon';
 import MoneyIcon from '../../components/common/icons/MoneyIcon';
 
 export default function DetailHeader({
-  detail: { title, account, total, members },
+  detail: {
+    title,
+    account: { bank, number },
+    total,
+    members,
+  },
   onUpdateButtonClick,
 }) {
   return (
     <header className={styles.header}>
       <h2 className={styles.title}>{title}</h2>
-      <dl className={styles['bank-group']}>
-        <BankIcon />
-        <dt className={styles.bank}>{account.bank}</dt>
-        <dd className={styles.number}>{account.number}</dd>
-      </dl>
+      {((bank && bank.trim().length !== 0) || number) && (
+        <dl className={styles['bank-group']}>
+          <BankIcon />
+          {<dt className={styles.bank}>{bank && bank.trim().length !== 0 ? bank : '_'}</dt>}
+          {<dd className={styles.number}>{number ? number : '_'}</dd>}
+        </dl>
+      )}
       <div className={styles.amount}>
         <MoneyIcon />
         <strong className={styles.total}>{total.toLocaleString()}원</strong>

--- a/src/pages/Detail/UpdateHeader.jsx
+++ b/src/pages/Detail/UpdateHeader.jsx
@@ -41,15 +41,18 @@ export default function UpdateHeader({
             onChange={handleChange}
             width='short'
             size='small'
+            placeholder='[선택사항]'
           />
           <Input
-            type='number'
+            type='text'
+            inputMode='numeric'
             name='number'
             text='계좌번호'
             value={info}
             onChange={handleChange}
             width='long'
             size='small'
+            placeholder='[선택사항] 숫자만 입력해주세요.'
           />
         </div>
         <div className={styles.container}>

--- a/src/pages/Detail/css/DetailHeader.module.css
+++ b/src/pages/Detail/css/DetailHeader.module.css
@@ -37,7 +37,7 @@
 }
 
 .bank {
-  max-width: 3.75rem;
+  max-width: 7rem;
   margin-right: 0.25rem;
 }
 

--- a/src/utils/checkAccountNumberRegExp.js
+++ b/src/utils/checkAccountNumberRegExp.js
@@ -1,0 +1,8 @@
+/**
+ * 계좌번호 정규식 검사
+ * @example 12312345555
+ * @param number 계좌번호
+ */
+export default function checkAccountNumberRegExp(number) {
+  return /^[0-9]+$/.test(number);
+}


### PR DESCRIPTION
# PR 설명
- 계좌 정보를 선택 사항으로 변경하여 개인 정보를 입력하지 않아도 이용할 수 있도록 변경
- number 타입의 계좌번호를 string 타입으로 변경

# 작업 내용
- 계좌번호를 string 타입으로 변경
- 계좌번호로 숫자만 입력할 수 있도록 정규식 추가
- 모임 생성 시, 은행과 계좌번호를 선택사항으로 변경
- 모임 수정 시, 은행과 계좌번호를 선택사항으로 변경
- 계좌정보가 없으면 UI를 표시하지 않도록 변경


# Screenshot
| 모임 생성 | 모임 수정 |
| --- | --- | 
| ![image](https://github.com/presentKey/gather/assets/115006670/6741101f-897c-4c46-a463-101c3da46e0b) |  ![image](https://github.com/presentKey/gather/assets/115006670/453d37f6-6e08-4438-98bb-d54cdb0629a1) | 

| 계좌정보가 없는 경우 | 계좌정보가 있는 경우 |
| --- |  --- |
| ![image](https://github.com/presentKey/gather/assets/115006670/28dc19f3-3c26-4931-a532-817287a15949) | ![image](https://github.com/presentKey/gather/assets/115006670/cedac257-15a1-45ca-967b-6109deb6c3fd) |

