### PR TITLE
모임 카드의 은행명 ellipsis 개선

### DIFF
--- a/src/components/Main/css/ClassCard.module.css
+++ b/src/components/Main/css/ClassCard.module.css
@@ -48,7 +48,7 @@
 }
 
 .number {
-  width: 16.25rem;
+  max-width: 16.25rem;
 }
 
 .member-content {


### PR DESCRIPTION
# PR 설명
모임 카드의 은행명이 ellipsis 처리되어 보기 힘든 문제 개선

# 작업 내용
- 짧은 텍스트는 ellipsis 처리되지 않도록 `ClassCard`의 .number 클래스를 max-width로 변경


# Screenshot
| 개선 전 | 개선 후 |
| --- | --- |
|  ![image](https://github.com/presentKey/gather/assets/115006670/f50fe94f-1ce9-43f5-b2d1-9a211da993bc) | ![image](https://github.com/presentKey/gather/assets/115006670/f35f4252-8b07-4da7-9d61-5d91a5895b0f) |



